### PR TITLE
Adds a `plok:sidebar` Rails generator that will prep the necessary files for a backend sidebar.

### DIFF
--- a/app/assets/javascripts/plok/sidebar.js
+++ b/app/assets/javascripts/plok/sidebar.js
@@ -1,0 +1,66 @@
+var sidebar = {
+  init: () => {
+    sidebar.bind_mouse_events();
+    $('#hamburger').on('click', sidebar.toggle_hamburger_click_listener)
+    $(document).on('click', sidebar.document_click_listener)
+  },
+
+  bind_mouse_events: () => {
+    $('.wrapper.compact ul li.top-level')
+      .on('mouseenter', sidebar.list_item_mouseenter_listener)
+      .on('mouseleave', sidebar.list_item_mouseleave_listener)
+  },
+
+  close_all_submenus: () => {
+    $('[id^="nav-"]').each((_i, item) => { $(item).removeClass('show') })
+    $('a.top-level-anchor').each((_i, item) => { $(item).removeClass('bg-secondary') })
+  },
+
+  document_click_listener: (e) => {
+    if($('.compact:visible').length == 0) return
+    if($(e.target).closest('.sidebar-menu').length === 0)
+      sidebar.close_all_submenus();
+  },
+
+  list_item_mouseenter_listener: (e) => {
+    sidebar.list_item_mouseleave_listener(e)
+
+    let anchor = $(e.target)
+    if(!anchor.hasClass('top-level-anchor')) return
+    anchor.addClass('bg-secondary')
+    $(anchor.attr('href')).addClass('show')
+  },
+
+  list_item_mouseleave_listener: (e) => {
+    let anchor = $(e.target)
+    if(!anchor.hasClass('top-level-anchor')) return
+    sidebar.close_all_submenus();
+  },
+
+  toggle_hamburger_click_listener: e => {
+    e.preventDefault()
+    $('.wrapper').toggleClass('compact')
+
+    $('[id^="nav-"]').each((index, item) => {
+      if($('.wrapper').hasClass('compact')) {
+        $(item).removeClass('show')
+      }
+    })
+
+    if($('.wrapper').hasClass('compact')) {
+      sidebar.bind_mouse_events()
+      $('.sidebar-menu').removeClass('overflow-auto')
+    } else {
+      sidebar.unbind_mouse_events()
+      $('.sidebar-menu').addClass('overflow-auto')
+    }
+  },
+
+  unbind_mouse_events: () => {
+    $('.wrapper ul li.top-level')
+      .off('mouseenter')
+      .off('mouseleave')
+  }
+}
+
+$(() => { sidebar.init() })

--- a/app/assets/stylesheets/plok/_sidebar.scss
+++ b/app/assets/stylesheets/plok/_sidebar.scss
@@ -1,0 +1,85 @@
+.sidebar-menu {
+  bottom: 0;
+  position: fixed;
+  top: 0;
+  width: var(--sidebar-width);
+  transition: .5s;
+
+  a.logo {
+    display: block;
+    letter-spacing: 0.1em;
+    line-height: 45px;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  a.home-icon {
+    display: none !important;
+  }
+
+  ul {
+    list-style-type: none;
+    padding-left: 0;
+
+    li {
+      cursor: pointer;
+
+      a {
+        color: $color-contrast-light;
+        display: block;
+        font-size: 1rem;
+        padding: 10px;
+        padding-left: var(--sidebar-menu-item-left-margin);
+        text-decoration: none !important;
+
+        &:hover {
+          background-color: $secondary;
+        }
+      }
+
+      &.top-level {
+        letter-spacing: .05em;
+        position: relative;
+
+        .fa {
+          font-size: 14px;
+          width: var(--sidebar-icon-width);
+        }
+
+        .text {
+          cursor: default;
+          font-size: 0.8rem;
+          padding: 16px 0 12px 0;
+          pointer-events: none;
+          text-transform: uppercase;
+        }
+
+        div[id^=nav-] {
+          h4 {
+            display: none;
+          }
+
+          ul li {
+            position: relative;
+
+            &::before {
+              content: '\25A1';
+              font-size: 0.4rem;
+              left: calc(var(--sidebar-menu-item-left-margin) + 15px);
+              position: absolute;
+              top: 15px;
+            }
+
+            a {
+              font-size: 0.8rem;
+              padding-left: calc(var(--sidebar-menu-item-left-margin) + var(--sidebar-icon-width) + 10px);
+              text-transform: uppercase;
+            }
+          }
+        }
+
+      }
+    }
+  }
+
+}

--- a/app/assets/stylesheets/plok/_sidebar.scss
+++ b/app/assets/stylesheets/plok/_sidebar.scss
@@ -4,6 +4,7 @@
   top: 0;
   width: var(--sidebar-width);
   transition: .5s;
+  z-index: 10;
 
   a.logo {
     display: block;

--- a/app/assets/stylesheets/plok/_sidebar.scss
+++ b/app/assets/stylesheets/plok/_sidebar.scss
@@ -25,7 +25,7 @@
       cursor: pointer;
 
       a {
-        color: $color-contrast-light;
+        color: #fff; // $color-contrast-light from the Bootstrap gem.
         display: block;
         font-size: 1rem;
         padding: 10px;
@@ -33,7 +33,7 @@
         text-decoration: none !important;
 
         &:hover {
-          background-color: $secondary;
+          background-color: #6c757d; // $secondary from the Bootstrap gem.
         }
       }
 

--- a/app/assets/stylesheets/plok/_sidebar_compact.scss
+++ b/app/assets/stylesheets/plok/_sidebar_compact.scss
@@ -1,0 +1,66 @@
+.wrapper.compact {
+  .content {
+    margin-left: var(--sidebar-compact-width);
+
+    @include media-breakpoint-down(md) {
+      margin-left: 0;
+    }
+  }
+
+  .sidebar-menu {
+    width: var(--sidebar-compact-width);
+
+    @include media-breakpoint-down(md) {
+      width: 0;
+    }
+
+    a.logo {
+      display: none !important;
+    }
+
+    a.home-icon {
+      display: block !important;
+    }
+
+    ul li.top-level {
+      > a { // The icons in the compact view.
+        padding: 10px 0;
+        text-align: center;
+      }
+
+      h4 {
+        cursor: default;
+        display: inline-block;
+        font-size: .9rem;
+        padding: 13px 0 0 5px;
+        vertical-align: middle;
+        text-transform: uppercase;
+      }
+
+      ul li {
+        &::before {
+          left: calc(var(--sidebar-icon-width) - 5px);
+        }
+
+        a {
+          padding-left: calc(var(--sidebar-icon-width) + 10px);
+
+          &:hover {
+            background-color: $primary;
+          }
+        }
+      }
+
+      .fa { font-size: 20px; }
+      .text { display: none; }
+
+      .collapse {
+        background-color: $secondary;
+        left: var(--sidebar-compact-width);
+        position: absolute;
+        top: 0;
+        width: 240px;
+      }
+    }
+  }
+}

--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
-1.0.0 - xxxx-xx-xx
+1.0.0 - 2022-06-17
 --
-* Add the Module class to use 'takes' initializers in classes.
+* Added the Module class to use 'takes' initializers in classes.
+* Added the plok:sidebar generator to generate a functional backend sidebar.
 
 
 0.2.12 - 2022-05-12

--- a/lib/generators/plok/sidebar/USAGE
+++ b/lib/generators/plok/sidebar/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Explain the generator
+
+Example:
+    bin/rails generate plok/sidebar Thing
+
+    This will create:
+        what/will/it/create

--- a/lib/generators/plok/sidebar/USAGE
+++ b/lib/generators/plok/sidebar/USAGE
@@ -2,7 +2,7 @@ Description:
     Explain the generator
 
 Example:
-    bin/rails generate plok/sidebar Thing
+    bin/rails generate plok/sidebar
 
     This will create:
         what/will/it/create

--- a/lib/generators/plok/sidebar/sidebar_generator.rb
+++ b/lib/generators/plok/sidebar/sidebar_generator.rb
@@ -4,7 +4,7 @@ class Plok::SidebarGenerator < Rails::Generators::Base
   source_root File.expand_path('templates', __dir__)
 
   def install
-    copy_sidebar_files('wrapper', 'menu_item', 'offcanvas_menu')
+    copy_sidebar_files('wrapper', 'menu_items', 'menu_item', 'offcanvas_menu')
     add_imports_to_application_scss
     inject_wrapper_block_into_application_layout
   end

--- a/lib/generators/plok/sidebar/sidebar_generator.rb
+++ b/lib/generators/plok/sidebar/sidebar_generator.rb
@@ -5,20 +5,34 @@ class Plok::SidebarGenerator < Rails::Generators::Base
 
   def install
     copy_sidebar_files('wrapper', 'menu_items', 'menu_item', 'offcanvas_menu')
-    add_imports_to_application_scss
+    add_scss_imports_to_application
+    add_js_imports_to_application
     inject_wrapper_block_into_application_layout
+    say("\nAll done! Remember to reboot your server so the new assets can load.\n\n")
   end
 
   private
 
-  def add_imports_to_application_scss
-    if application_scss_file
-      unless file_contains?(application_scss_file, /@import 'plok\/sidebar'/)
-        append_to_file application_scss_file, "@import 'plok/sidebar';\n"
+  def add_js_imports_to_application
+    if application_file(:js)
+      unless file_contains?(application_file(:js), /\/\/= require plok\/sidebar/)
+        append_to_file application_file(:js), "//= require plok/sidebar"
+      end
+    else
+      say("\nWARNING: No suitable application.js file found.\n")
+      say("Please add the following import to your backend application.js file:\n\n")
+      say("//= require plok/sidebar\n\n")
+    end
+  end
+
+  def add_scss_imports_to_application
+    if application_file(:scss)
+      unless file_contains?(application_file(:scss), /@import 'plok\/sidebar'/)
+        append_to_file application_file(:scss), "@import 'plok/sidebar';\n"
       end
 
-      unless file_contains?(application_scss_file, /@import 'plok\/sidebar_compact'/)
-        append_to_file application_scss_file, "@import 'plok/sidebar_compact';\n"
+      unless file_contains?(application_file(:scss), /@import 'plok\/sidebar_compact'/)
+        append_to_file application_file(:scss), "@import 'plok/sidebar_compact';\n"
       end
     else
       say("\nWARNING: No suitable application.scss file found.\n")
@@ -84,13 +98,16 @@ class Plok::SidebarGenerator < Rails::Generators::Base
     end
   end
 
-  def application_scss_file
-    if File.exists?('app/assets/stylesheets/backend/bs5/application.scss')
-      return 'app/assets/stylesheets/backend/bs5/application.scss'
+  def application_file(type)
+    namespace = 'stylesheets'
+    namespace = 'javascripts' if type.to_s == 'js'
+
+    if File.exists?("app/assets/#{namespace}/backend/bs5/application.#{type}")
+      return "app/assets/#{namespace}/backend/bs5/application.#{type}"
     end
 
-    if File.exists?('app/assets/stylesheets/backend/application.scss')
-      return 'app/assets/stylesheets/backend/application.scss'
+    if File.exists?("app/assets/#{namespace}/backend/application.#{type}")
+      return "app/assets/#{namespace}/backend/application.#{type}"
     end
   end
 end

--- a/lib/generators/plok/sidebar/sidebar_generator.rb
+++ b/lib/generators/plok/sidebar/sidebar_generator.rb
@@ -2,6 +2,7 @@ require 'rails/generators/base'
 
 class Plok::SidebarGenerator < Rails::Generators::Base
   source_root File.expand_path('templates', __dir__)
+  class_option :css_framework, type: :string, default: 'bs5'
 
   def install
     copy_sidebar_files('wrapper', 'menu_items', 'menu_item', 'offcanvas_menu')
@@ -51,7 +52,7 @@ class Plok::SidebarGenerator < Rails::Generators::Base
       say("\nWARNING: The generator could not inject the sidebar wrapper.\n")
       say("You will have to wrap your backend application markup in this block:\n\n")
       say("# #{application_layout_file}\n")
-      say("<%= render 'backend/bs5/sidebar/wrapper', brand_name: '#{app_name}' do %>\n")
+      say("<%= render 'backend/#{options.css_framework}/sidebar/wrapper', brand_name: '#{app_name}' do %>\n")
       say("  # ...your backend application markup here...\n")
       say("<% end %>\n")
       return
@@ -60,7 +61,7 @@ class Plok::SidebarGenerator < Rails::Generators::Base
     gsub_file(
       application_layout_file,
       /<body(.*)>\n/,
-      "<body\\1>\n  <%= render 'backend/bs5/sidebar/wrapper', brand_name: '#{app_name}' do %>\n"
+      "<body\\1>\n  <%= render 'backend/#{options.css_framework}/sidebar/wrapper', brand_name: '#{app_name}' do %>\n"
     )
 
     gsub_file(
@@ -81,7 +82,7 @@ class Plok::SidebarGenerator < Rails::Generators::Base
   end
 
   def sidebar_partial_path(partial_name)
-    "app/views/backend/bs5/sidebar/_#{partial_name}.html.erb"
+    "app/views/backend/#{options.css_framework}/sidebar/_#{partial_name}.html.erb"
   end
 
   def file_contains?(file, content)
@@ -89,8 +90,8 @@ class Plok::SidebarGenerator < Rails::Generators::Base
   end
 
   def application_layout_file
-    if File.exists?('app/views/layouts/backend/bs5/application.html.erb')
-      return 'app/views/layouts/backend/bs5/application.html.erb'
+    if File.exists?("app/views/layouts/backend/#{options.css_framework}/application.html.erb")
+      return "app/views/layouts/backend/#{options.css_framework}/application.html.erb"
     end
 
     if File.exists?('app/views/layouts/backend/application.html.erb')
@@ -102,8 +103,8 @@ class Plok::SidebarGenerator < Rails::Generators::Base
     namespace = 'stylesheets'
     namespace = 'javascripts' if type.to_s == 'js'
 
-    if File.exists?("app/assets/#{namespace}/backend/bs5/application.#{type}")
-      return "app/assets/#{namespace}/backend/bs5/application.#{type}"
+    if File.exists?("app/assets/#{namespace}/backend/#{options.css_framework}/application.#{type}")
+      return "app/assets/#{namespace}/backend/#{options.css_framework}/application.#{type}"
     end
 
     if File.exists?("app/assets/#{namespace}/backend/application.#{type}")

--- a/lib/generators/plok/sidebar/sidebar_generator.rb
+++ b/lib/generators/plok/sidebar/sidebar_generator.rb
@@ -3,10 +3,20 @@ require 'rails/generators/base'
 class Plok::SidebarGenerator < Rails::Generators::Base
   source_root File.expand_path('templates', __dir__)
 
-  def copy_initializer_file
+  def install
     copy_sidebar_files('wrapper', 'menu_item', 'offcanvas_menu')
     gsub_file sidebar_partial_path('wrapper'), '[brand_name]', app_name
     gsub_file sidebar_partial_path('offcanvas_menu'), '[brand_name]', app_name
+
+    if application_scss_file
+      append_to_file application_scss_file, "@import 'plok/sidebar';\n"
+      append_to_file application_scss_file, "@import 'plok/sidebar_compact';\n"
+    else
+      say("WARNING: No suitable application.scss file found.\n")
+      say("Please add the following imports to your backend application.scss file:\n\n")
+      say("@import 'plok/sidebar';\n")
+      say("@import 'plok/sidebar_compact';\n")
+    end
   end
 
   private
@@ -23,5 +33,15 @@ class Plok::SidebarGenerator < Rails::Generators::Base
 
   def sidebar_partial_path(partial_name)
     "app/views/backend/bs5/sidebar/_#{partial_name}.html.erb"
+  end
+
+  def application_scss_file
+    if File.exists?('app/assets/stylesheets/backend/bs5/application.scss')
+      return 'app/assets/stylesheets/backend/bs5/application.scss'
+    end
+
+    if File.exists?('app/assets/stylesheets/backend/application.scss')
+      return 'app/assets/stylesheets/backend/application.scss'
+    end
   end
 end

--- a/lib/generators/plok/sidebar/sidebar_generator.rb
+++ b/lib/generators/plok/sidebar/sidebar_generator.rb
@@ -27,13 +27,13 @@ class Plok::SidebarGenerator < Rails::Generators::Base
     gsub_file(
       application_layout_file,
       /<body(.*)>\n/,
-      "<body\\1>\n    <%= render 'backend/bs5/sidebar/wrapper', brand_name: '#{app_name}' do %>\n"
+      "<body\\1>\n  <%= render 'backend/bs5/sidebar/wrapper', brand_name: '#{app_name}' do %>\n"
     )
 
     gsub_file(
       application_layout_file,
-      %Q(\n    <%= yield(:javascripts_early) %>),
-      "    <% end %>\n\n    <%= yield(:javascripts_early) %>"
+      /\n(.*)<%= yield\(:javascripts_early\) %>/,
+      "  <% end %>\n\n\\1<%= yield(:javascripts_early) %>"
     )
   end
 

--- a/lib/generators/plok/sidebar/sidebar_generator.rb
+++ b/lib/generators/plok/sidebar/sidebar_generator.rb
@@ -1,0 +1,27 @@
+require 'rails/generators/base'
+
+class Plok::SidebarGenerator < Rails::Generators::Base
+  source_root File.expand_path('templates', __dir__)
+
+  def copy_initializer_file
+    copy_sidebar_files('wrapper', 'menu_item', 'offcanvas_menu')
+    gsub_file sidebar_file_path('wrapper'), '[brand_name]', app_name
+    gsub_file sidebar_file_path('offcanvas_menu'), '[brand_name]', app_name
+  end
+
+  private
+
+  def app_name
+    Rails.application.class.name.split('::').first
+  end
+
+  def copy_sidebar_files(*partials)
+    partials.each do |partial_name|
+      copy_file "_#{partial_name}.html.erb", sidebar_file_path(partial_name)
+    end
+  end
+
+  def sidebar_file_path(partial_name)
+    "app/views/backend/bs5/sidebar/_#{partial_name}.html.erb"
+  end
+end

--- a/lib/generators/plok/sidebar/sidebar_generator.rb
+++ b/lib/generators/plok/sidebar/sidebar_generator.rb
@@ -5,8 +5,8 @@ class Plok::SidebarGenerator < Rails::Generators::Base
 
   def copy_initializer_file
     copy_sidebar_files('wrapper', 'menu_item', 'offcanvas_menu')
-    gsub_file sidebar_file_path('wrapper'), '[brand_name]', app_name
-    gsub_file sidebar_file_path('offcanvas_menu'), '[brand_name]', app_name
+    gsub_file sidebar_partial_path('wrapper'), '[brand_name]', app_name
+    gsub_file sidebar_partial_path('offcanvas_menu'), '[brand_name]', app_name
   end
 
   private
@@ -17,11 +17,11 @@ class Plok::SidebarGenerator < Rails::Generators::Base
 
   def copy_sidebar_files(*partials)
     partials.each do |partial_name|
-      copy_file "_#{partial_name}.html.erb", sidebar_file_path(partial_name)
+      copy_file "_#{partial_name}.html.erb", sidebar_partial_path(partial_name)
     end
   end
 
-  def sidebar_file_path(partial_name)
+  def sidebar_partial_path(partial_name)
     "app/views/backend/bs5/sidebar/_#{partial_name}.html.erb"
   end
 end

--- a/lib/generators/plok/sidebar/templates/_menu_item.html.erb
+++ b/lib/generators/plok/sidebar/templates/_menu_item.html.erb
@@ -1,0 +1,13 @@
+<% lbl ||= t("b.#{name}") %>
+
+<%= content_tag :li, class: 'top-level' do %>
+  <%= link_to "#nav-#{name}", class: 'top-level-anchor link-light', data: { bs_toggle: 'collapse' } do %>
+    <%= fa_icon icon, class: 'fa-fw' %>
+    <%= content_tag :span, lbl, class: 'text' %>
+  <% end %>
+
+  <%= content_tag :div, id: "nav-#{name}", class: 'collapse' do %>
+    <h4><%= lbl %></h4>
+    <%= yield %>
+  <% end %>
+<% end %>

--- a/lib/generators/plok/sidebar/templates/_menu_item.html.erb
+++ b/lib/generators/plok/sidebar/templates/_menu_item.html.erb
@@ -1,13 +1,16 @@
 <% lbl ||= t("b.#{name}") %>
+<% href ||= defined?(path) ? path : "#nav-#{name}" %>
 
 <%= content_tag :li, class: 'top-level' do %>
-  <%= link_to "#nav-#{name}", class: 'top-level-anchor link-light', data: { bs_toggle: 'collapse' } do %>
+  <%= link_to href, class: 'top-level-anchor link-light', data: { bs_toggle: ('collapse' unless defined?(path)) } do %>
     <%= fa_icon icon, class: 'fa-fw' %>
     <%= content_tag :span, lbl, class: 'text' %>
   <% end %>
 
-  <%= content_tag :div, id: "nav-#{name}", class: 'collapse' do %>
-    <h4><%= lbl %></h4>
-    <%= yield %>
+  <% unless defined?(path) %>
+    <%= content_tag :div, id: "nav-#{name}", class: 'collapse' do %>
+      <h4><%= lbl %></h4>
+      <%= yield %>
+    <% end %>
   <% end %>
 <% end %>

--- a/lib/generators/plok/sidebar/templates/_menu_items.html.erb
+++ b/lib/generators/plok/sidebar/templates/_menu_items.html.erb
@@ -1,0 +1,9 @@
+<ul class="justify-content-center">
+  <%= render 'backend/bs5/sidebar/menu_item', name: 'admins', icon: 'user-secret-o' do %>
+    <ul>
+      <%= content_tag :li do %>
+        <%= link_to t('b.overview'), backend_admins_path %>
+      <% end %>
+    </ul>
+  <% end %>
+</ul>

--- a/lib/generators/plok/sidebar/templates/_offcanvas_menu.html.erb
+++ b/lib/generators/plok/sidebar/templates/_offcanvas_menu.html.erb
@@ -1,6 +1,6 @@
 <div class="offcanvas offcanvas-start bg-dark text-light" tabindex="-1" id="navigation-offcanvas">
   <div class="offcanvas-header">
-    <h5 class="offcanvas-title">[brand_name]</h5>
+    <h5 class="offcanvas-title"><%= brand_name %></h5>
     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
   <div class="offcanvas-body">

--- a/lib/generators/plok/sidebar/templates/_offcanvas_menu.html.erb
+++ b/lib/generators/plok/sidebar/templates/_offcanvas_menu.html.erb
@@ -1,0 +1,11 @@
+<div class="offcanvas offcanvas-start bg-dark text-light" tabindex="-1" id="navigation-offcanvas">
+  <div class="offcanvas-header">
+    <h5 class="offcanvas-title">[brand_name]</h5>
+    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+  </div>
+  <div class="offcanvas-body">
+    <div class="sidebar-menu position-static">
+      <%= render 'backend/sidebar_menu' %>
+    </div>
+  </div>
+</div>

--- a/lib/generators/plok/sidebar/templates/_offcanvas_menu.html.erb
+++ b/lib/generators/plok/sidebar/templates/_offcanvas_menu.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="offcanvas-body">
     <div class="sidebar-menu position-static">
-      <%= render 'backend/sidebar_menu' %>
+      <%= render 'backend/bs5/sidebar/menu_items' %>
     </div>
   </div>
 </div>

--- a/lib/generators/plok/sidebar/templates/_wrapper.html.erb
+++ b/lib/generators/plok/sidebar/templates/_wrapper.html.erb
@@ -1,5 +1,5 @@
-<div class="wrapper <%= current_admin.sidebar_style %>">
-  <div class="sidebar-menu text-light bg-dark <%= 'overflow-auto' if current_admin.sidebar_style == 'regular' %>">
+<div class="wrapper">
+  <div class="sidebar-menu text-light bg-dark overflow-auto">
     <%= link_to backend_path, class: 'text-center navbar-brand logo text-light me-0' do %>
       <%= brand_name %>
     <% end %>

--- a/lib/generators/plok/sidebar/templates/_wrapper.html.erb
+++ b/lib/generators/plok/sidebar/templates/_wrapper.html.erb
@@ -1,0 +1,19 @@
+<div class="wrapper <%= current_admin.sidebar_style %>">
+  <div class="sidebar-menu text-light bg-dark <%= 'overflow-auto' if current_admin.sidebar_style == 'regular' %>">
+    <%= link_to backend_path, class: 'text-center navbar-brand logo text-light me-0' do %>
+      [brand_name]
+    <% end %>
+
+    <%= link_to fa_icon(:'home'), backend_path, class: 'text-center navbar-brand home-icon text-light fs-2 me-0' %>
+
+    <nav class="mt-3">
+      <%= render 'backend/sidebar_menu' %>
+    </nav>
+  </div>
+
+  <div class="content">
+    <%= yield %>
+  </div>
+</div>
+
+<%= render 'backend/bs5/sidebar/offcanvas_menu', brand_name: brand_name %>

--- a/lib/generators/plok/sidebar/templates/_wrapper.html.erb
+++ b/lib/generators/plok/sidebar/templates/_wrapper.html.erb
@@ -7,7 +7,7 @@
     <%= link_to fa_icon(:'home'), backend_path, class: 'text-center navbar-brand home-icon text-light fs-2 me-0' %>
 
     <nav class="mt-3">
-      <%= render 'backend/sidebar_menu' %>
+      <%= render 'backend/bs5/sidebar/menu_items' %>
     </nav>
   </div>
 

--- a/lib/generators/plok/sidebar/templates/_wrapper.html.erb
+++ b/lib/generators/plok/sidebar/templates/_wrapper.html.erb
@@ -1,7 +1,7 @@
 <div class="wrapper <%= current_admin.sidebar_style %>">
   <div class="sidebar-menu text-light bg-dark <%= 'overflow-auto' if current_admin.sidebar_style == 'regular' %>">
     <%= link_to backend_path, class: 'text-center navbar-brand logo text-light me-0' do %>
-      [brand_name]
+      <%= brand_name %>
     <% end %>
 
     <%= link_to fa_icon(:'home'), backend_path, class: 'text-center navbar-brand home-icon text-light fs-2 me-0' %>

--- a/lib/plok/version.rb
+++ b/lib/plok/version.rb
@@ -1,3 +1,3 @@
 module Plok
-  VERSION = '0.2.12'
+  VERSION = '1.0.0'
 end

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,17 @@
 # Plok
 
+## Backend sidebar navigation component
+A `plok:sidebar` generator was added that'll copy over the necessary markup
+files for a mobile-friendly sidebar component in your backend:
+
+```bash
+bin/rails g plok:sidebar
+```
+
+Note that it will only copy markup files so as to guarantee uniform
+functionality across our backends, especially in regards to the JS. Meanwhile, 
+custom changes or additions to the CSS should be made in supplementary files.
+
 ## Overriding models
 You might want to add something to a Plok model at some point. As an example, 
 let's override `Log`.

--- a/spec/generator/plok/plok_sidebar_generator_spec.rb
+++ b/spec/generator/plok/plok_sidebar_generator_spec.rb
@@ -1,4 +1,0 @@
-require 'rails_helper'
-
-describe "Plok::Sidebar", type: :generator do
-end

--- a/spec/generator/plok/plok_sidebar_generator_spec.rb
+++ b/spec/generator/plok/plok_sidebar_generator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+describe "Plok::Sidebar", type: :generator do
+end

--- a/spec/lib/generators/plok/sidebar/sidebar_generator_spec.rb
+++ b/spec/lib/generators/plok/sidebar/sidebar_generator_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+require 'rails/generators'
+require 'rails/generators/actions'
+require 'rails/generators/base'
+require Rails.root.join('../../lib/generators/plok/sidebar/sidebar_generator.rb').to_s
+
+describe Plok::SidebarGenerator, type: :generator do
+  # TODO: Find out how to init a generator subject properly.
+  #it 'copies files' do
+    #expect { subject.install }.to change {
+      #File.exist?('app/views/plok/sidebar.html.erb')
+    #}.from(false).to(true)
+  #end
+end


### PR DESCRIPTION
Processes AC-25170

## TODO
- [ ] ~~Look up the DSL lingo on how to properly test generators~~.
  **UPDATE** This looks less evident than anticipated, so best left out for now.
- [x] Add sidebar assets to the templates folder and copy them.
- [x] Inject the assets into `app/assets/{stylesheets,javascripts}/backend/application.{(s)css,js}` files.
- [x] Test and review installations in Oximo, Reli, and Typografics.
- [ ] Decide what to do with `current_admin` and `current_admin.sidebar_style` (or otherwise put, `AdminSetting`)